### PR TITLE
Support mushroom theme variables in template card

### DIFF
--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -7,7 +7,12 @@ jobs:
         runs-on: ubuntu-latest
         steps:
             - name: Checkout
-              uses: actions/checkout@v2
+              uses: actions/checkout@v4
+            - name: Setup Node.js
+              uses: actions/setup-node@v4
+              with:
+                  node-version: 20
+                  cache: npm
             - name: Install
               run: npm ci
             - name: Build

--- a/.github/workflows/release.yaml
+++ b/.github/workflows/release.yaml
@@ -8,13 +8,18 @@ jobs:
         runs-on: ubuntu-latest
         steps:
             - name: Checkout
-              uses: actions/checkout@v2
-            - name: Install
+              uses: actions/checkout@v4
+            - name: Setup Node.js
+              uses: actions/setup-node@v4
+              with:
+                  node-version: 20
+                  cache: npm
+            - name: Install dependencies
               run: npm ci
-            - name: Build
+            - name: Build distribution bundle
               run: npm run build
-            - name: Release
-              uses: softprops/action-gh-release@v1
+            - name: Publish release assets
+              uses: softprops/action-gh-release@v2
               if: startsWith(github.ref, 'refs/tags/')
               with:
                   draft: true

--- a/.github/workflows/validate.yaml
+++ b/.github/workflows/validate.yaml
@@ -3,13 +3,18 @@ on:
     push:
         branches:
             - main
+    pull_request:
 jobs:
     validate:
         runs-on: ubuntu-latest
         steps:
             - name: Checkout
-              uses: actions/checkout@v2
-            - name: HACS validation
-              uses: "hacs/action@main"
+              uses: actions/checkout@v4
+            - name: Setup Python
+              uses: actions/setup-python@v5
               with:
-                  category: "plugin"
+                  python-version: "3.12"
+            - name: HACS validation
+              uses: hacs/action@main
+              with:
+                  category: plugin

--- a/README.md
+++ b/README.md
@@ -10,6 +10,8 @@
 
 ![Overview](https://user-images.githubusercontent.com/5878303/152332130-760cf616-5c40-4825-a482-bb8f1f0f5251.png)
 
+> **Credit:** Mushroom is created and maintained by [piitaya](https://github.com/piitaya). This fork exists solely to keep the new template card compatible with Mushroom theme variables.
+
 ## What is mushroom ?
 
 Mushroom is a collection of cards for [Home Assistant][home-assistant] Dashboard UI.
@@ -37,7 +39,7 @@ Mushroom is available in [HACS][hacs] (Home Assistant Community Store).
 
 Use this link to directly go to the repository in HACS
 
-[![Open your Home Assistant instance and open a repository inside the Home Assistant Community Store.](https://my.home-assistant.io/badges/hacs_repository.svg)](https://my.home-assistant.io/redirect/hacs_repository/?owner=piitaya&repository=lovelace-mushroom)
+[![Open your Home Assistant instance and open a repository inside the Home Assistant Community Store.](https://my.home-assistant.io/badges/hacs_repository.svg)](https://my.home-assistant.io/redirect/hacs_repository/?owner=runemg&repository=lovelace-mushroom)
 
 _or_
 

--- a/hacs.json
+++ b/hacs.json
@@ -1,6 +1,7 @@
 {
-  "name": "Mushroom",
+  "name": "Mushroom DIY",
   "filename": "mushroom.js",
-  "homeassistant": "2025.6",
-  "render_readme": true
+  "homeassistant": "2025.6.0",
+  "render_readme": true,
+  "content_in_root": false
 }

--- a/info.md
+++ b/info.md
@@ -1,0 +1,10 @@
+# Mushroom DIY template card
+
+Mushroom DIY is a fork of [piitaya/lovelace-mushroom](https://github.com/piitaya/lovelace-mushroom)
+that keeps the new template card aligned with the classic Mushroom theme variables.
+It ships the built `mushroom.js` bundle that HACS installs as a Lovelace plugin.
+
+## Installation
+
+Use [HACS](https://hacs.xyz/) and add the repository as a custom Lovelace plugin,
+or download `mushroom.js` from the latest release and place it in `config/www`.

--- a/package.json
+++ b/package.json
@@ -14,7 +14,7 @@
   "author": "Paul Bottein",
   "repository": {
     "type": "git",
-    "url": "https://github.com/piitaya/lovelace-mushroom"
+    "url": "https://github.com/runemg/lovelace-mushroom"
   },
   "license": "ISC",
   "dependencies": {

--- a/src/cards/template-card/template-card.ts
+++ b/src/cards/template-card/template-card.ts
@@ -486,29 +486,37 @@ export class MushroomTemplateCard extends LitElement implements LovelaceCard {
                   ? html`
                       <ha-tile-info
                         id="info"
-                        .primary=${supportTileInfoSlot ? undefined : primary}
+                        .primary=${supportTileInfoSlot
+                          ? undefined
+                          : html`
+                              <span class="primary-text"
+                                >${primary ?? ""}</span
+                              >
+                            `}
                         .secondary=${supportTileInfoSlot
                           ? undefined
                           : html`
                               <span
-                                style=${styleMap({
-                                  "white-space": multilineSecondary
-                                    ? "pre-wrap"
-                                    : "nowrap",
+                                class=${classMap({
+                                  "secondary-text": true,
+                                  multiline: Boolean(multilineSecondary),
                                 })}
-                                >${secondary?.trim()}</span
+                                >${secondary?.trim() ?? ""}</span
                               >
                             `}
                       >
                         ${supportTileInfoSlot
                           ? html`
-                              <span slot="primary">${primary}</span>
+                              <span slot="primary" class="primary-text"
+                                >${primary ?? ""}</span
+                              >
                               <span
                                 slot="secondary"
                                 class=${classMap({
+                                  "secondary-text": true,
                                   multiline: Boolean(multilineSecondary),
                                 })}
-                                >${secondary}</span
+                                >${secondary ?? ""}</span
                               >
                             `
                           : nothing}
@@ -608,19 +616,44 @@ export class MushroomTemplateCard extends LitElement implements LovelaceCard {
         flex: none;
       }
 
-      .multiline {
+      .primary-text {
+        font-weight: var(--card-primary-font-weight);
+        font-size: var(--card-primary-font-size);
+        line-height: var(--card-primary-line-height);
+        color: var(--card-primary-color);
+        letter-spacing: var(--card-primary-letter-spacing);
+        text-overflow: ellipsis;
+        overflow: hidden;
+        white-space: nowrap;
+        display: block;
+      }
+      .secondary-text {
+        font-weight: var(--card-secondary-font-weight);
+        font-size: var(--card-secondary-font-size);
+        line-height: var(--card-secondary-line-height);
+        color: var(--card-secondary-color);
+        letter-spacing: var(--card-secondary-letter-spacing);
+        text-overflow: ellipsis;
+        overflow: hidden;
+        white-space: nowrap;
+        display: block;
+      }
+      .secondary-text.multiline {
         white-space: pre-wrap;
       }
 
       ha-tile-icon {
+        --tile-icon-border-radius: var(--icon-border-radius);
         --tile-icon-color: var(--tile-color);
+        --tile-icon-size: var(--icon-size);
+        --tile-icon-symbol-size: var(--icon-symbol-size);
         position: relative;
         padding: 6px;
         margin: -6px;
       }
       ha-tile-icon.weather svg {
-        width: 36px;
-        height: 36px;
+        width: var(--icon-size);
+        height: var(--icon-size);
         display: flex;
       }
       ha-tile-icon.weather {


### PR DESCRIPTION
## Summary
- ensure the new template card uses Mushroom theme text classes so mushroom card typography variables apply to primary and secondary lines
- map icon styling to the existing mushroom icon theme variables for size, border radius, and symbol sizing
- document that this fork simply credits piitaya and exists to keep the template card compatible with mushroom variables
- point the HACS quick link at this fork instead of piitaya's original repository

## Testing
- `npm run build`


------
https://chatgpt.com/codex/tasks/task_e_68ce7482a9108328bd66ddf6ef90d658