### PR TITLE
Add diy legacy card copy

### DIFF
--- a/src/cards/diy-legacy-card/const.ts
+++ b/src/cards/diy-legacy-card/const.ts
@@ -1,0 +1,4 @@
+import { PREFIX_NAME } from "../../const";
+
+export const DIY_LEGACY_CARD_NAME = `${PREFIX_NAME}-diy-legacy-card`;
+export const DIY_LEGACY_CARD_EDITOR_NAME = `${DIY_LEGACY_CARD_NAME}-editor`;

--- a/src/cards/diy-legacy-card/diy-legacy-card-config.ts
+++ b/src/cards/diy-legacy-card/diy-legacy-card-config.ts
@@ -1,0 +1,51 @@
+import {
+  array,
+  assign,
+  boolean,
+  object,
+  optional,
+  string,
+  union,
+} from "superstruct";
+import { LovelaceCardConfig } from "../../ha";
+import {
+  ActionsSharedConfig,
+  actionsSharedConfigStruct,
+} from "../../shared/config/actions-config";
+import {
+  AppearanceSharedConfig,
+  appearanceSharedConfigStruct,
+} from "../../shared/config/appearance-config";
+import { lovelaceCardConfigStruct } from "../../shared/config/lovelace-card-config";
+
+export type DiyLegacyCardConfig = LovelaceCardConfig &
+  AppearanceSharedConfig &
+  ActionsSharedConfig & {
+    entity?: string;
+    icon?: string;
+    icon_color?: string;
+    primary?: string;
+    secondary?: string;
+    badge_icon?: string;
+    badge_color?: string;
+    picture?: string;
+    multiline_secondary?: boolean;
+    entity_id?: string | string[];
+  };
+
+export const diyLegacyCardConfigStruct = assign(
+  lovelaceCardConfigStruct,
+  assign(appearanceSharedConfigStruct, actionsSharedConfigStruct),
+  object({
+    entity: optional(string()),
+    icon: optional(string()),
+    icon_color: optional(string()),
+    primary: optional(string()),
+    secondary: optional(string()),
+    badge_icon: optional(string()),
+    badge_color: optional(string()),
+    picture: optional(string()),
+    multiline_secondary: optional(boolean()),
+    entity_id: optional(union([string(), array(string())])),
+  })
+);

--- a/src/cards/diy-legacy-card/diy-legacy-card-editor.ts
+++ b/src/cards/diy-legacy-card/diy-legacy-card-editor.ts
@@ -1,0 +1,133 @@
+import { html, nothing } from "lit";
+import { customElement, state } from "lit/decorators.js";
+import { assert } from "superstruct";
+import { LovelaceCardEditor, fireEvent } from "../../ha";
+import setupCustomlocalize from "../../localize";
+import { computeActionsFormSchema } from "../../shared/config/actions-config";
+import { MushroomBaseElement } from "../../utils/base-element";
+import { GENERIC_LABELS } from "../../utils/form/generic-fields";
+import { HaFormSchema } from "../../utils/form/ha-form";
+import { loadHaComponents } from "../../utils/loader";
+import { DIY_LEGACY_CARD_EDITOR_NAME } from "./const";
+import {
+  DiyLegacyCardConfig,
+  diyLegacyCardConfigStruct,
+} from "./diy-legacy-card-config";
+
+export const TEMPLATE_LABELS = [
+  "badge_icon",
+  "badge_color",
+  "content",
+  "primary",
+  "secondary",
+  "multiline_secondary",
+  "picture",
+];
+
+const SCHEMA: HaFormSchema[] = [
+  { name: "entity", selector: { entity: {} } },
+  {
+    name: "icon",
+    selector: { template: {} },
+  },
+  {
+    name: "icon_color",
+    selector: { template: {} },
+  },
+  {
+    name: "primary",
+    selector: { template: {} },
+  },
+  {
+    name: "secondary",
+    selector: { template: {} },
+  },
+  {
+    name: "badge_icon",
+    selector: { template: {} },
+  },
+  {
+    name: "badge_color",
+    selector: { template: {} },
+  },
+  {
+    name: "picture",
+    selector: { template: {} },
+  },
+  {
+    type: "grid",
+    name: "",
+    schema: [
+      { name: "layout", selector: { mush_layout: {} } },
+      { name: "fill_container", selector: { boolean: {} } },
+      { name: "multiline_secondary", selector: { boolean: {} } },
+    ],
+  },
+  ...computeActionsFormSchema(),
+];
+
+@customElement(DIY_LEGACY_CARD_EDITOR_NAME)
+export class TemplateCardEditor
+  extends MushroomBaseElement
+  implements LovelaceCardEditor
+{
+  @state() private _config?: DiyLegacyCardConfig;
+
+  connectedCallback() {
+    super.connectedCallback();
+    void loadHaComponents();
+  }
+
+  public setConfig(config: DiyLegacyCardConfig): void {
+    assert(config, diyLegacyCardConfigStruct);
+    this._config = config;
+  }
+
+  private _computeLabel = (schema: HaFormSchema) => {
+    const customLocalize = setupCustomlocalize(this.hass!);
+
+    if (schema.name === "entity") {
+      return `${this.hass!.localize(
+        "ui.panel.lovelace.editor.card.generic.entity"
+      )}`;
+    }
+    if (GENERIC_LABELS.includes(schema.name)) {
+      return customLocalize(`editor.card.generic.${schema.name}`);
+    }
+    if (TEMPLATE_LABELS.includes(schema.name)) {
+      return customLocalize(`editor.card.template.${schema.name}`);
+    }
+    return this.hass!.localize(
+      `ui.panel.lovelace.editor.card.generic.${schema.name}`
+    );
+  };
+
+  private _computeHelper = (schema: HaFormSchema) => {
+    const customLocalize = setupCustomlocalize(this.hass!);
+    if (schema.name === "entity") {
+      return customLocalize("editor.card.template.entity_helper_legacy");
+    }
+    return undefined;
+  };
+
+  protected render() {
+    if (!this.hass || !this._config) {
+      return nothing;
+    }
+
+    return html`
+      <ha-form
+        .hass=${this.hass}
+        .data=${this._config}
+        .schema=${SCHEMA}
+        .computeLabel=${this._computeLabel}
+        .computeHelper=${this._computeHelper}
+        @value-changed=${this._valueChanged}
+      ></ha-form>
+    `;
+  }
+
+  private _valueChanged(ev: CustomEvent): void {
+    fireEvent(this, "config-changed", { config: ev.detail.value });
+  }
+}

--- a/src/cards/diy-legacy-card/diy-legacy-card.ts
+++ b/src/cards/diy-legacy-card/diy-legacy-card.ts
@@ -1,11 +1,20 @@
 import { UnsubscribeFunc } from "home-assistant-js-websocket";
 import {
-  ActionConfig,
+  css,
+  CSSResultGroup,
+  html,
+  nothing,
+  PropertyValues,
+  TemplateResult,
+} from "lit";
+import { customElement, property, state } from "lit/decorators.js";
+import { classMap } from "lit/directives/class-map.js";
+import { styleMap } from "lit/directives/style-map.js";
+import hash from "object-hash/dist/object_hash";
+import {
   actionHandler,
   ActionHandlerEvent,
-  computeDomain,
   computeRTL,
-  DOMAINS_TOGGLE,
   handleAction,
   hasAction,
   HomeAssistant,
@@ -16,19 +25,6 @@ import {
   RenderTemplateResult,
   subscribeRenderTemplate,
 } from "../../ha";
-import {
-  css,
-  CSSResultGroup,
-  html,
-  nothing,
-  PropertyValues,
-  TemplateResult,
-} from "lit";
-import { customElement, property, state } from "lit/decorators.js";
-import { classMap } from "lit/directives/class-map.js";
-import { ifDefined } from "lit/directives/if-defined.js";
-import { styleMap } from "lit/directives/style-map.js";
-import hash from "object-hash/dist/object_hash";
 import "../../shared/shape-icon";
 import "../../shared/state-info";
 import "../../shared/state-item";
@@ -37,9 +33,14 @@ import { MushroomBaseElement } from "../../utils/base-element";
 import { CacheManager } from "../../utils/cache-manager";
 import { cardStyle } from "../../utils/card-styles";
 import { computeRgbColor } from "../../utils/colors";
+import { registerCustomCard } from "../../utils/custom-cards";
 import { getWeatherSvgIcon } from "../../utils/icons/weather-icon";
 import { weatherSVGStyles } from "../../utils/weather";
-import { LegacyTemplateCardConfig } from "../legacy-template-card/legacy-template-card-config";
+import {
+  DIY_LEGACY_CARD_EDITOR_NAME,
+  DIY_LEGACY_CARD_NAME,
+} from "./const";
+import { DiyLegacyCardConfig } from "./diy-legacy-card-config";
 
 const templateCache = new CacheManager<TemplateResults>(1000);
 
@@ -58,48 +59,30 @@ const TEMPLATE_KEYS = [
 ] as const;
 type TemplateKey = (typeof TEMPLATE_KEYS)[number];
 
-const DIY_TEMPLATE_CARD_NAME = "mushroom-diy-template-card";
-const DIY_TEMPLATE_CARD_EDITOR_NAME = "mushroom-template-card-editor";
-
-export const getEntityDefaultTileIconAction = (entityId: string) => {
-  const domain = computeDomain(entityId);
-  const supportsIconAction =
-    DOMAINS_TOGGLE.has(domain) ||
-    ["button", "input_button", "scene"].includes(domain);
-
-  return supportsIconAction ? "toggle" : "none";
-};
-
-type DiyTemplateCardConfig = LegacyTemplateCardConfig & {
-  icon_tap_action?: ActionConfig;
-  icon_hold_action?: ActionConfig;
-  icon_double_tap_action?: ActionConfig;
-};
-
-@customElement(DIY_TEMPLATE_CARD_NAME)
-export class MushroomDiyTemplateCard
+@customElement(DIY_LEGACY_CARD_NAME)
+export class DiyLegacyCard
   extends MushroomBaseElement
   implements LovelaceCard
 {
   public static async getConfigElement(): Promise<LovelaceCardEditor> {
-    await import("../template-card/template-card-editor");
+    await import("./diy-legacy-card-editor");
     return document.createElement(
-      DIY_TEMPLATE_CARD_EDITOR_NAME
+      DIY_LEGACY_CARD_EDITOR_NAME
     ) as LovelaceCardEditor;
   }
 
   public static async getStubConfig(
     _hass: HomeAssistant
-  ): Promise<DiyTemplateCardConfig> {
+  ): Promise<DiyLegacyCardConfig> {
     return {
-      type: `custom:${DIY_TEMPLATE_CARD_NAME}`,
+      type: `custom:${DIY_LEGACY_CARD_NAME}`,
       primary: "Hello, {{user}}",
       secondary: "How are you?",
       icon: "mdi:home",
     };
   }
 
-  @state() private _config?: DiyTemplateCardConfig;
+  @state() private _config?: DiyLegacyCardConfig;
 
   @state() private _templateResults?: TemplateResults;
 
@@ -161,7 +144,7 @@ export class MushroomDiyTemplateCard
     return options;
   }
 
-  setConfig(config: DiyTemplateCardConfig): void {
+  setConfig(config: DiyLegacyCardConfig): void {
     TEMPLATE_KEYS.forEach((key) => {
       if (
         this._config?.[key] !== config[key] ||
@@ -179,12 +162,6 @@ export class MushroomDiyTemplateCard
       },
       ...config,
     };
-
-    if (this._config.entity && !this._config.icon_tap_action) {
-      this._config.icon_tap_action = {
-        action: getEntityDefaultTileIconAction(this._config.entity),
-      };
-    }
   }
 
   public connectedCallback() {
@@ -226,17 +203,6 @@ export class MushroomDiyTemplateCard
     handleAction(this, this.hass!, this._config!, ev.detail.action!);
   }
 
-  private _handleIconAction(ev: ActionHandlerEvent) {
-    ev.stopPropagation();
-    const config = {
-      entity: this._config!.entity,
-      tap_action: this._config!.icon_tap_action,
-      hold_action: this._config!.icon_hold_action,
-      double_tap_action: this._config!.icon_double_tap_action,
-    };
-    handleAction(this, this.hass!, config, ev.detail.action!);
-  }
-
   public isTemplate(key: TemplateKey) {
     const value = this._config?.[key];
     return value?.includes("{");
@@ -246,14 +212,6 @@ export class MushroomDiyTemplateCard
     return this.isTemplate(key)
       ? this._templateResults?.[key]?.result?.toString()
       : this._config?.[key];
-  }
-
-  private get _hasIconAction() {
-    return (
-      hasAction(this._config?.icon_tap_action) ||
-      hasAction(this._config?.icon_hold_action) ||
-      hasAction(this._config?.icon_double_tap_action)
-    );
   }
 
   protected render() {
@@ -304,23 +262,7 @@ export class MushroomDiyTemplateCard
             ${picture
               ? this.renderPicture(picture)
               : weatherSvg
-                ? html`
-                    <div
-                      slot="icon"
-                      role=${ifDefined(this._hasIconAction ? "button" : undefined)}
-                      tabindex=${ifDefined(this._hasIconAction ? "0" : undefined)}
-                      @action=${this._handleIconAction}
-                      .actionHandler=${actionHandler({
-                        disabled: !this._hasIconAction,
-                        hasHold: hasAction(this._config?.icon_hold_action),
-                        hasDoubleClick: hasAction(
-                          this._config?.icon_double_tap_action
-                        ),
-                      })}
-                    >
-                      ${weatherSvg}
-                    </div>
-                  `
+                ? html`<div slot="icon">${weatherSvg}</div>`
                 : icon
                   ? this.renderIcon(icon, iconColor)
                   : nothing}
@@ -344,14 +286,6 @@ export class MushroomDiyTemplateCard
       <mushroom-shape-avatar
         slot="icon"
         .picture_url=${(this.hass as any).hassUrl(picture)}
-        role=${ifDefined(this._hasIconAction ? "button" : undefined)}
-        tabindex=${ifDefined(this._hasIconAction ? "0" : undefined)}
-        @action=${this._handleIconAction}
-        .actionHandler=${actionHandler({
-          disabled: !this._hasIconAction,
-          hasHold: hasAction(this._config?.icon_hold_action),
-          hasDoubleClick: hasAction(this._config?.icon_double_tap_action),
-        })}
       ></mushroom-shape-avatar>
     `;
   }
@@ -364,18 +298,7 @@ export class MushroomDiyTemplateCard
       iconStyle["--shape-color"] = `rgba(${iconRgbColor}, 0.2)`;
     }
     return html`
-      <mushroom-shape-icon
-        style=${styleMap(iconStyle)}
-        slot="icon"
-        role=${ifDefined(this._hasIconAction ? "button" : undefined)}
-        tabindex=${ifDefined(this._hasIconAction ? "0" : undefined)}
-        @action=${this._handleIconAction}
-        .actionHandler=${actionHandler({
-          disabled: !this._hasIconAction,
-          hasHold: hasAction(this._config?.icon_hold_action),
-          hasDoubleClick: hasAction(this._config?.icon_double_tap_action),
-        })}
-      >
+      <mushroom-shape-icon style=${styleMap(iconStyle)} slot="icon">
         <ha-state-icon .hass=${this.hass} .icon=${icon}></ha-state-icon>
       </mushroom-shape-icon>
     `;

--- a/src/mushroom.ts
+++ b/src/mushroom.ts
@@ -20,6 +20,7 @@ import "./cards/entity-card/entity-card";
 import "./cards/fan-card/fan-card";
 import "./cards/humidifier-card/humidifier-card";
 import "./cards/legacy-template-card/legacy-template-card";
+import "./cards/diy-legacy-card/diy-legacy-card";
 import "./cards/diy-template-card/diy-template-card";
 import "./cards/light-card/light-card";
 import "./cards/lock-card/lock-card";


### PR DESCRIPTION
## Summary
- add a new diy-legacy-card that mirrors the legacy-template-card implementation under its own element name
- load the diy legacy card from the Mushroom entrypoint so it is bundled alongside the existing cards

## Testing
- npm run build

------
https://chatgpt.com/codex/tasks/task_e_68d0eab71e748328b2073f57e06fb87a